### PR TITLE
publish: set deploy strategy to rolling

### DIFF
--- a/voyager-publish/fly.toml
+++ b/voyager-publish/fly.toml
@@ -20,3 +20,6 @@ primary_region = 'cdg'
   memory = '1gb'
   cpu_kind = 'shared'
   cpus = 1
+
+[deploy]
+  strategy = "rolling"


### PR DESCRIPTION
To ensure only one instance is running at a time