### PR TITLE
fix: report child pid (lock value) on crash

### DIFF
--- a/voyager-publish/bin/voyager-publish.js
+++ b/voyager-publish/bin/voyager-publish.js
@@ -76,7 +76,7 @@ await Promise.all(new Array(CONCURRENCY).fill().map(async () => {
     ps.stderr.pipe(process.stderr)
     const [code] = await once(ps, 'exit')
     if (code !== 0) {
-      console.error(`Bad exit code: ${code}`)
+      console.error(`Bad exit code: ${code} (child pid: ${ps.pid}`)
       Sentry.captureMessage(`Bad exit code: ${code}`)
       rpcUrlIndex++
     }


### PR DESCRIPTION
This allows us to manually clear the lock column or delete the published measurements based on the information found in the logs.
