### PR TITLE
fix: skip `VACUUM measurements` when too many rows

### DIFF
--- a/voyager-publish/index.js
+++ b/voyager-publish/index.js
@@ -139,8 +139,12 @@ export const publish = async ({
     }
   }
 
-  logger.log('Vacuuming measurements')
-  await pgPool.query('VACUUM measurements')
+  if (totalCount > 1_000_000) {
+    console.log('Skipping `VACUUM measurements` - the table is too large')
+  } else {
+    logger.log('Vacuuming measurements')
+    await pgPool.query('VACUUM measurements')
+  }
 
   // TODO: Add cleanup
   // We're not sure if we're going to stick with web3.storage, or switch to


### PR DESCRIPTION
At the moment, the oldest VACUUM run has been running for 03h20m and hasn't finished yet.
